### PR TITLE
exec "$@" instead of tailing

### DIFF
--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -2,4 +2,5 @@
 
 chmod -R o+w /home/pi/pialert/db
 /etc/init.d/lighttpd start
-service cron start && tail -f /dev/null
+service cron start
+exec "$@"


### PR DESCRIPTION
Just wanted to see if we could keep it working using exec "$@" instead.

Can ya test this for me? It's just to make it a little prettier.