### PR TITLE
Fix timezone issues and duplicate down notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /home/pi/pialert
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    # && sed -i.bak 's/^TIMEZONE=.*/TIMEZONE='${TZ}'/' /home/pi/pialert/config/pialert.conf \
+    sed "s+TIMEZONE.*+TIMEZONE = '" ${TZ} "'+" /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /home/pi/pialert
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    && sed -i.bak 's/^TIMEZONE=.*/TIMEZONE='\'${TZ}\''/' /home/pi/pialert/config/pialert.conf \
+    && sed -i.bak 's/^TIMEZONE=.*/TIMEZONE='${TZ}'/' /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /home/pi/pialert
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    && sed -i.bak 's/^\(TIMEZONE=\).*/\'${TZ}'/' /home/pi/pialert/config/pialert.conf \
+    && sed -i.bak 's/^\(TIMEZONE=\).*/\ '${TZ}'/' /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /home/pi/pialert
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    && sed -i.bak 's/^TIMEZONE=.*/TIMEZONE='${TZ}'/' /home/pi/pialert/config/pialert.conf \
+    # && sed -i.bak 's/^TIMEZONE=.*/TIMEZONE='${TZ}'/' /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,12 @@ RUN groupadd --gid "${USER_GID}" "${USER}" && \
 
 COPY . /home/pi/pialert
 
+RUN chmod -R a+rxw /home/pi/pialert/
+
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    && sed "s+TIMEZONE.*+TIMEZONE = '" ${TZ} "'+" /home/pi/pialert/config/pialert.conf \
+    && sed "s+TIMEZONE.*+TIMEZONE = '"${TZ}"'+" /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,9 @@ RUN groupadd --gid "${USER_GID}" "${USER}" && \
 
 COPY . /home/pi/pialert
 
-RUN chmod -R a+rxw /home/pi/pialert/
-
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    && sed "s+TIMEZONE.*+TIMEZONE = '"${TZ}"'+" /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /home/pi/pialert
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    sed "s+TIMEZONE.*+TIMEZONE = '" ${TZ} "'+" /home/pi/pialert/config/pialert.conf \
+    && sed "s+TIMEZONE.*+TIMEZONE = '" ${TZ} "'+" /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /home/pi/pialert
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
-    && sed -i.bak 's/^\(TIMEZONE=\).*/\ '${TZ}'/' /home/pi/pialert/config/pialert.conf \
+    && sed -i.bak 's/^TIMEZONE=.*/TIMEZONE='\'${TZ}\''/' /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY . /home/pi/pialert
 # Pi.Alert 
 RUN python /home/pi/pialert/back/pialert.py update_vendors \    
     && sed -ie 's/= 80/= '${PORT}'/g' /etc/lighttpd/lighttpd.conf \
+    && sed -i.bak 's/^\(TIMEZONE=\).*/\'${TZ}'/' /home/pi/pialert/config/pialert.conf \
     && (crontab -l 2>/dev/null; cat /home/pi/pialert/install/pialert.cron) | crontab -
 
 # it's easy for permissions set in Git to be overridden, so doing it manually

--- a/back/pialert.py
+++ b/back/pialert.py
@@ -1184,6 +1184,11 @@ def email_reporting ():
                         (
                             SELECT dev_MAC FROM Devices WHERE dev_AlertEvents = 0 
 						)""")
+    sql.execute ("""UPDATE Events SET eve_PendingAlertEmail = 0
+                    WHERE eve_PendingAlertEmail = 1 AND eve_EventType = 'Device Down' AND eve_MAC IN
+                        (
+                            SELECT dev_MAC FROM Devices WHERE dev_AlertDeviceDown = 0 
+						)""")
 
     # Open text Template
     template_file = open(PIALERT_BACK_PATH + '/report_template.txt', 'r') 

--- a/back/pialert.py
+++ b/back/pialert.py
@@ -1205,7 +1205,7 @@ def email_reporting ():
     mail_text = mail_text.replace ('<REPORT_DATE>', timeFormated)
     mail_html = mail_html.replace ('<REPORT_DATE>', timeFormated)
 
-    mail_text = mail_text.replace ('<SCAN_CYCLE>', cycle )
+    # mail_text = mail_text.replace ('<SCAN_CYCLE>', cycle )
     mail_html = mail_html.replace ('<SCAN_CYCLE>', cycle )
 
     mail_text = mail_text.replace ('<SERVER_NAME>', socket.gethostname() )

--- a/back/report_template.txt
+++ b/back/report_template.txt
@@ -1,12 +1,6 @@
 Report Date: <REPORT_DATE>
-Scan Cycle:  <SCAN_CYCLE>
 Server:      <SERVER_NAME>
-
-<SECTION_INTERNET>
-Internet
-----------------------
-<TABLE_INTERNET>
-</SECTION_INTERNET><SECTION_NEW_DEVICES>
+<SECTION_NEW_DEVICES>
 New Devices
 ----------------------
 <TABLE_NEW_DEVICES>
@@ -18,4 +12,8 @@ Devices Down
 Events
 ----------------------
 <TABLE_EVENTS>
-</SECTION_EVENTS>
+</SECTION_EVENTS><SECTION_INTERNET>
+Internet
+----------------------
+<TABLE_INTERNET>
+</SECTION_INTERNET>

--- a/config/version.conf
+++ b/config/version.conf
@@ -1,4 +1,3 @@
 VERSION           = '3.5_leiweibau'
 VERSION_YEAR      = '2022'
 VERSION_DATE      = '2022-07-07'
-TZ                = 'Europe/London'

--- a/front/php/server/db.php
+++ b/front/php/server/db.php
@@ -8,6 +8,13 @@
 //  Puche 2021        pi.alert.application@gmail.com        GNU GPLv3
 //------------------------------------------------------------------------------
 
+// ## TimeZone processing
+$config_file = "../config/pialert.conf";
+$config_file_lines = file($config_file);
+$config_file_lines_timezone = array_values(preg_grep('/^TIMEZONE\s.*/', $config_file_lines));
+$timezone_line = explode("'", $config_file_lines_timezone[0]);
+$Pia_TimeZone = $timezone_line[1];
+date_default_timezone_set($Pia_TimeZone);
 
 //------------------------------------------------------------------------------
 // DB File Path

--- a/front/php/server/db.php
+++ b/front/php/server/db.php
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 // ## TimeZone processing
-$config_file = "../config/pialert.conf";
+$config_file = "../../../config/pialert.conf";
 $config_file_lines = file($config_file);
 $config_file_lines_timezone = array_values(preg_grep('/^TIMEZONE\s.*/', $config_file_lines));
 $timezone_line = explode("'", $config_file_lines_timezone[0]);

--- a/front/php/server/devices.php
+++ b/front/php/server/devices.php
@@ -7,6 +7,13 @@
 //------------------------------------------------------------------------------
 //  Puche 2021        pi.alert.application@gmail.com        GNU GPLv3
 //------------------------------------------------------------------------------
+// ## TimeZone processing
+$config_file = "../../../config/pialert.conf";
+$config_file_lines = file($config_file);
+$config_file_lines_timezone = array_values(preg_grep('/^TIMEZONE\s.*/', $config_file_lines));
+$timezone_line = explode("'", $config_file_lines_timezone[0]);
+$Pia_TimeZone = $timezone_line[1];
+date_default_timezone_set($Pia_TimeZone);
 
 foreach (glob("../../../db/setting_language*") as $filename) {
     $pia_lang_selected = str_replace('setting_language_','',basename($filename));

--- a/front/php/server/devices.php
+++ b/front/php/server/devices.php
@@ -116,8 +116,10 @@ function getDeviceData() {
   $row = $result -> fetchArray (SQLITE3_NUM);
   $deviceData['dev_DownAlerts'] = $row[0];
 
+  // Get current date using php, sql datetime does not return time respective to timezone.
+  $currentdate = date("Y-m-d H:i:s");
   // Presence hours
-  $sql = 'SELECT CAST(( MAX (0, SUM (julianday (IFNULL (ses_DateTimeDisconnection, DATETIME("now","localtime")))
+  $sql = 'SELECT CAST(( MAX (0, SUM (julianday (IFNULL (ses_DateTimeDisconnection,"'. $currentdate .'" ))
                                      - julianday (CASE WHEN ses_DateTimeConnection < '. $periodDate .' THEN '. $periodDate .'
                                                        ELSE ses_DateTimeConnection END)) *24 )) AS INT)
           FROM Sessions

--- a/front/php/server/events.php
+++ b/front/php/server/events.php
@@ -7,7 +7,13 @@
 //------------------------------------------------------------------------------
 //  Puche 2021        pi.alert.application@gmail.com        GNU GPLv3
 //------------------------------------------------------------------------------
-
+// ## TimeZone processing
+$config_file = "../../../config/pialert.conf";
+$config_file_lines = file($config_file);
+$config_file_lines_timezone = array_values(preg_grep('/^TIMEZONE\s.*/', $config_file_lines));
+$timezone_line = explode("'", $config_file_lines_timezone[0]);
+$Pia_TimeZone = $timezone_line[1];
+date_default_timezone_set($Pia_TimeZone);
 
 //------------------------------------------------------------------------------
   // External files

--- a/front/php/server/events.php
+++ b/front/php/server/events.php
@@ -275,7 +275,7 @@ function getDevicePresence() {
                  END AS ses_DateTimeConnectionCorrected,
 
                  CASE
-                   WHEN ses_EventTypeDisconnection = "<missing event>" THEN
+                   WHEN ses_EventTypeDisconnection = "<missing event>" OR ses_EventTypeDisconnection = NULL THEN
                         (SELECT MIN(ses_DateTimeConnection) FROM Sessions AS SES2 WHERE SES2.ses_MAC = SES1.ses_MAC AND SES2.ses_DateTimeConnection > SES1.ses_DateTimeConnection)
                    ELSE ses_DateTimeDisconnection
                  END AS ses_DateTimeDisconnectionCorrected

--- a/front/php/server/util.php
+++ b/front/php/server/util.php
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 // ## TimeZone processing
-$config_file = "../config/pialert.conf";
+$config_file = "../../../config/pialert.conf";
 $config_file_lines = file($config_file);
 $config_file_lines_timezone = array_values(preg_grep('/^TIMEZONE\s.*/', $config_file_lines));
 $timezone_line = explode("'", $config_file_lines_timezone[0]);

--- a/front/php/server/util.php
+++ b/front/php/server/util.php
@@ -8,6 +8,13 @@
 //  Puche 2021        pi.alert.application@gmail.com        GNU GPLv3
 //------------------------------------------------------------------------------
 
+// ## TimeZone processing
+$config_file = "../config/pialert.conf";
+$config_file_lines = file($config_file);
+$config_file_lines_timezone = array_values(preg_grep('/^TIMEZONE\s.*/', $config_file_lines));
+$timezone_line = explode("'", $config_file_lines_timezone[0]);
+$Pia_TimeZone = $timezone_line[1];
+date_default_timezone_set($Pia_TimeZone);
 
 //------------------------------------------------------------------------------
 // Formatting data functions


### PR DESCRIPTION
Fixes #48 fully.  It was a timezone error where SQL would not fetch the correct time relative to the current system timezone. This has now been fixed and presence graphs should work properly.

Should fix #51. Please confirm. Adds extra check before sending notification.

Removes cycle from text report because it does not provide useful information since there is only one scan cycle.