### PR TITLE
change GET to POST at send_webhook

### DIFF
--- a/back/pialert.py
+++ b/back/pialert.py
@@ -1631,7 +1631,7 @@ def send_webhook (_json, _html):
         curlParams = ["curl","-i","-H", "Content-Type:application/json" ,"-d", json.dumps(_json_payload), _WEBHOOK_URL]
     else:
         _WEBHOOK_URL = WEBHOOK_URL
-        curlParams = ["curl","-i","-X", "GET" ,"-H", "Content-Type:application/json" ,"-d", json.dumps(_json_payload), _WEBHOOK_URL]
+        curlParams = ["curl","-i","-X", "POST" ,"-H", "Content-Type:application/json" ,"-d", json.dumps(_json_payload), _WEBHOOK_URL]
 
     # execute CURL call
     p = subprocess.Popen(curlParams, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
I am using Node RED http-in node to receive this payload, and GET is ignoring the body, changing to POST is accepted. Reading a bit about that, I saw that some more servers ignore body on GET, so, maybe best option is to choose if you want to send GET or POST, maybe adding that to pyalert.conf