### PR TITLE
Webhook text

### DIFF
--- a/back/pialert.py
+++ b/back/pialert.py
@@ -1618,7 +1618,7 @@ def send_webhook (_json, _html):
     try:
         eventLevel = EVENT_LEVEL
     except NameError: # variable not defined, use a default
-        eventLevel = 4 # report on everythin
+        eventLevel = 4 # report on everything
 
     # use data type based on specified payload type
     if webhookPayload == 'json':
@@ -1855,7 +1855,7 @@ def to_text(_json, eventLevel):
                 payloadData += event[8] + " on " + event[1] + " " + event[3] + " at " + event[2] + "\n"
 
     return payloadData
-    
+
 #===============================================================================
 # BEGIN
 #===============================================================================

--- a/config/pialert.conf
+++ b/config/pialert.conf
@@ -15,6 +15,7 @@ PRINT_LOG               = False
 TIMEZONE                = 'Europe/Berlin'
 PIALERT_WEB_PROTECTION  = False
 PIALERT_WEB_PASSWORD    = '8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92'
+INCLUDED_SECTIONS       = ['internet', 'new_devices', 'down_devices', 'events']
 
 # EMAIL settings
 # ----------------------

--- a/config/pialert.conf
+++ b/config/pialert.conf
@@ -36,10 +36,11 @@ REPORT_DASHBOARD_URL    = 'http://pi.alert/'
 REPORT_WEBHOOK          = False
 WEBHOOK_URL             = 'http://n8n.local:5555/webhook-test/aaaaaaaa-aaaa-aaaa-aaaaa-aaaaaaaaaaaa'
 # webhook payload data format for the "body > attachements > text" attribute in https://github.com/jokob-sk/Pi.Alert/blob/main/docs/webhook_json_sample.json
-#   supported values: 'json' or 'html' 
+#   supported values: 'json' or 'html' or 'text'
 #   e.g.: for discord use 'html'
 WEBHOOK_PAYLOAD         = 'json'  
 WEBHOOK_REQUEST_METHOD  = 'GET'  # POST, GET...
+EVENT_LEVEL             = 5
 
 # Apprise settings
 #-----------------------

--- a/config/pialert.conf
+++ b/config/pialert.conf
@@ -40,7 +40,8 @@ WEBHOOK_URL             = 'http://n8n.local:5555/webhook-test/aaaaaaaa-aaaa-aaaa
 #   e.g.: for discord use 'html'
 WEBHOOK_PAYLOAD         = 'json'  
 WEBHOOK_REQUEST_METHOD  = 'GET'  # POST, GET...
-EVENT_LEVEL             = 5
+# set event level to 0 for no message, 1 for Internet changes only, 2 for new devices and 1, 3 for down devices and 2 and 4 for events and 3. i.e. everything
+EVENT_LEVEL             = 4
 
 # Apprise settings
 #-----------------------


### PR DESCRIPTION
I've made a couple of minor changes I hope you will accept with reference to #96:

- There is now a `text` option for `WEBHOOK_PAYLOAD` to just send plain text compatible with Slack and Google chat and others

- You can set a reporting level using a new config called `EVENT_LEVEL`.
0 - No reports
1 - Internet changes only
2 - New devices (plus the above)
3 - Down devices (plus above)
4 - Events (plus above) i.e. everything

The `EVENT_LEVEL` only applies to `text` payloads but if you want to use it for other types obviously you can. It's just to reduce the number of alerts. 