### PR TITLE
Reduce docker image size by setting permissions at copy stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,10 +8,6 @@ Dockerfile
 dockerfiles/LICENSE
 dockerfiles/README.md
 docs
-install/pialert_install.sh
-install/pialert_install_no_webserver.sh
-install/pialert_uninstall.sh
-install/pialert_update.sh
 LICENSE.txt
 README.md
-tar
+CONTRIBUTING

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,27 +15,26 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/www/html \
     && ln -s /home/pi/pialert/front /var/www/html 
- 
-   
-# now creating user
+
+# create pi user and group
+# add root and www-data to pi group so they can r/w files and db
 RUN groupadd --gid "${USER_GID}" "${USER}" && \
     useradd \
-      --uid ${USER_ID} \
-      --gid ${USER_GID} \
-      --create-home \
-      --shell /bin/bash \
-      ${USER}
+        --uid ${USER_ID} \
+        --gid ${USER_GID} \
+        --create-home \
+        --shell /bin/bash \
+        ${USER} && \
+    usermod -a -G ${USER_GID} root && \
+    usermod -a -G ${USER_GID} www-data
 
-COPY . /home/pi/pialert
+COPY --chmod=775 --chown=${USER_ID}:${USER_GID} . /home/pi/pialert/
 
-# Pi.Alert 
+# Pi.Alert
 RUN rm /etc/nginx/sites-available/default \
-	&& ln -s /home/pi/pialert/install/default /etc/nginx/sites-available/default \
+    && ln -s /home/pi/pialert/install/default /etc/nginx/sites-available/default \
     && sed -ie 's/listen 80/listen '${PORT}'/g' /etc/nginx/sites-available/default \
     # run the hardware vendors update
     && /home/pi/pialert/back/update_vendors.sh 
-
-# it's easy for permissions set in Git to be overridden, so doing it manually
-RUN chmod -R a+rxw /home/pi/pialert/
 
 CMD ["/home/pi/pialert/dockerfiles/start.sh"]


### PR DESCRIPTION
This PR reduces the uncompressed image size by about 50MB. This is because when RUN chmod is utilized all of the files where the permissions are changed become a new layer.

Instead this uses the relatively new COPY args --chmod and --chown. This may also help with other misc file permission issues as it will ensure all files are r/w by both root and www-data.

There are some other space saving possibilities, especially around the the update_vendors.sh script but I thought this would be a simple one to start with.