### PR TITLE
Move vendor update to first run instead of during build phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV USER=pi USER_ID=1000 USER_GID=1000 TZ=Europe/London PORT=20211
 
 RUN apt-get update \
     && apt-get install --no-install-recommends ca-certificates curl libwww-perl arp-scan perl apt-utils cron sudo nginx-light php php-cgi php-fpm php-sqlite3 php-curl sqlite3 dnsutils net-tools python3 iproute2 nmap python3-pip zip -y \
-    && pip3 install requests paho-mqtt  \
+    && pip3 install --no-cache-dir requests paho-mqtt  \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
     && apt-get clean autoclean \
     && apt-get autoremove \
@@ -33,8 +33,6 @@ COPY --chmod=775 --chown=${USER_ID}:${USER_GID} . /home/pi/pialert/
 # Pi.Alert
 RUN rm /etc/nginx/sites-available/default \
     && ln -s /home/pi/pialert/install/default /etc/nginx/sites-available/default \
-    && sed -ie 's/listen 80/listen '${PORT}'/g' /etc/nginx/sites-available/default \
-    # run the hardware vendors update
-    && /home/pi/pialert/back/update_vendors.sh 
+    && sed -ie 's/listen 80/listen '${PORT}'/g' /etc/nginx/sites-available/default
 
 CMD ["/home/pi/pialert/dockerfiles/start.sh"]

--- a/back/pialert.py
+++ b/back/pialert.py
@@ -150,7 +150,7 @@ last_network_scan = now_minus_24h
 last_internet_IP_scan = now_minus_24h
 last_run = now_minus_24h
 last_cleanup = now_minus_24h
-last_update_vendors = time_now - timedelta(days = 6) # update vendors 24h after first run and than once a week
+last_update_vendors = time_now - timedelta(days = 8) # update vendors on first run and than once a week
 
 def main ():
     # Initialize global variables


### PR DESCRIPTION
The vendor_update.sh script adds quite a bit of size to the total image. Moved this to kick off immediately on the first run.

I am not familiar with the internal workings of PiAlert so I am not sure if this delay could have an impact on the initial scan and inventory of devices. So feel free to reject this if it breaks things :).

Additionally added --no-cache-dir to the pip install step, only saves about 1MB but every bit helps right.

This shaves off about another 30MB from the uncompressed image.