### PR TITLE
Use path context so dockerignore is respected

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
+          context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -106,6 +107,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
+          context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Poking around the latest image noticed that the docs folder and other files are being included in the build COPY operation even though they are in the .dockerignore.
```bash
# pwd
/home/pi/pialert
# ls -lha
total 132K
drwxrwxrwx 1 root root 4.0K Dec 12 08:15 .
drwxr-xr-x 1 pi   pi   4.0K Dec 12 08:15 ..
-rwxrwxrwx 1 root root  268 Dec 12 08:14 .dockerignore
-rwxrwxrwx 1 root root  297 Dec 12 08:14 .env
drwxrwxrwx 1 root root 4.0K Dec 12 08:14 .github
-rwxrwxrwx 1 root root   47 Dec 12 08:14 .gitignore
-rwxrwxrwx 1 root root 1.5K Dec 12 08:14 Dockerfile
-rwxrwxrwx 1 root root  35K Dec 12 08:14 LICENSE.txt
-rwxrwxrwx 1 root root 6.4K Dec 12 08:14 README.md
drwxrwxrwx 1 root root 4.0K Dec 12 08:14 back
drwxrwxrwx 1 root root 4.0K Dec 18 18:06 config
drwxrwxrwx 1 root root 4.0K Dec 18 18:06 db
-rwxrwxrwx 1 root root 1.8K Dec 12 08:14 docker-compose.yml
drwxrwxrwx 1 root root 4.0K Dec 12 08:14 dockerfiles
drwxrwxrwx 1 root root 4.0K Dec 12 08:14 docs
drwxrwxrwx 1 root root 4.0K Dec 18 18:06 front
drwxrwxrwx 1 root root 4.0K Dec 12 08:14 install
```
Researching it seems like using the default git context of the build push action can make the .dockerignore get ignored. Solution is to use the path context instead. Should save some space especially since the docs jpg files are not very compressible.
https://github.com/docker/build-push-action#git-context