### PR TITLE
get_plugin_config changed to top level folders

### DIFF
--- a/back/pialert.py
+++ b/back/pialert.py
@@ -3770,9 +3770,12 @@ def get_plugins_configs():
     
     pluginsList = []
 
-    for root, dirs, files in os.walk(pluginsPath):
-        for d in dirs:            # Loop over directories, not files            
-            pluginsList.append(json.loads(get_file_content(pluginsPath + "/" + d + '/config.json')))          
+    # only top level directories required. No need for the loop
+    # for root, dirs, files in os.walk(pluginsPath):
+    
+    dirs = next(os.walk(pluginsPath))[1]
+    for d in dirs:            # Loop over directories, not files            
+        pluginsList.append(json.loads(get_file_content(pluginsPath + "/" + d + '/config.json')))          
 
     return pluginsList
 


### PR DESCRIPTION
the get_plugin_config function loops thru all directories (and sub directories) of the /front/plugins directory.
It does not need to go to subdirecotries and failed when there was a __pycache__ directory. 