### PR TITLE
Update pialert.py

### DIFF
--- a/back/pialert.py
+++ b/back/pialert.py
@@ -3784,8 +3784,9 @@ def get_plugins_configs():
     # for root, dirs, files in os.walk(pluginsPath):
     
     dirs = next(os.walk(pluginsPath))[1]
-    for d in dirs:            # Loop over directories, not files            
-        pluginsList.append(json.loads(get_file_content(pluginsPath + "/" + d + '/config.json')))          
+    for d in dirs:            # Loop over directories, not files
+	if not d.startswith( "__" ):        # ignore __pycache__ 
+            pluginsList.append(json.loads(get_file_content(pluginsPath + "/" + d + '/config.json')))          
 
     return pluginsList
 


### PR DESCRIPTION
add filter to ignore __pycache__ in plugin dir

since the helper is now in the plugins directory we need to filter out the __pycache__ directory it generates.