### PR TITLE
fix: docker cache to github registry mistake

### DIFF
--- a/.github/workflows/docker_dev.yml
+++ b/.github/workflows/docker_dev.yml
@@ -51,6 +51,13 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
 
+      - name: Log in to Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -66,5 +73,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=docker.io/jokobsk/pi.alert:buildcache
-          cache-to: type=registry,ref=docker.io/jokobsk/pi.alert:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/jokobsk/pi.alert:buildcache
+          cache-to: type=registry,ref=ghcr.io/jokobsk/pi.alert:buildcache,mode=max

--- a/.github/workflows/docker_prod.yml
+++ b/.github/workflows/docker_prod.yml
@@ -58,6 +58,13 @@ jobs:
             type=ref,event=pr
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
 
+      - name: Log in to Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -73,5 +80,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=docker.io/jokobsk/pi.alert:buildcache
-          cache-to: type=registry,ref=docker.io/jokobsk/pi.alert:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/jokobsk/pi.alert:buildcache
+          cache-to: type=registry,ref=ghcr.io/jokobsk/pi.alert:buildcache,mode=max


### PR DESCRIPTION
the docker cache was pointed incorrectly to docker hub making the cache location a problem and making the cleaner to fail.

additional info here: https://github.com/jokob-sk/Pi.Alert/pull/254#issuecomment-1605339822