### PR TITLE
UniFi: bugfix and new feature

### DIFF
--- a/front/plugins/unifi_import/config.json
+++ b/front/plugins/unifi_import/config.json
@@ -61,14 +61,14 @@
             "value" : "UNFIMP_sites"
         },
         {
-            "name"  : "protocol",
-            "type"  : "setting",
-            "value" : "UNFIMP_protocol"
-        },
-        {
             "name"  : "port",
             "type"  : "setting",
             "value" : "UNFIMP_port"
+        },
+        {
+            "name"  : "verifyssl",
+            "type"  : "setting",
+            "value" : "UNFIMP_verifyssl"
         },
         {
             "name"  : "version",
@@ -348,7 +348,7 @@
         {
             "function": "CMD",
             "type": "text",
-            "default_value":"python3 /home/pi/pialert/front/plugins/unifi_import/script.py username={username} password={password}  host={host} sites={sites}  protocol={protocol} port={port} version={version}",
+            "default_value":"python3 /home/pi/pialert/front/plugins/unifi_import/script.py username={username} password={password}  host={host} sites={sites} port={port} verifyssl={verifyssl} version={version}",
             "options": [],
             "localized": ["name", "description"],
             "name" : [{
@@ -415,29 +415,6 @@
             }]
         },
         {
-            "function": "protocol",
-            "type": "text.select",
-            "default_value":"https://",
-            "options": ["https://", "http://"],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Protocol"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Protocolo"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "The protocol to use to access the controller."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "El protocolo a utilizar para acceder al controlador."
-            }]
-        },
-        {
             "function": "host",
             "type": "text",
             "default_value":"192.168.1.1",
@@ -481,6 +458,29 @@
             {
                 "language_code":"es_es",
                 "string" : "El número de puerto donde se ejecuta el controlador UNIFI. Normalmente es <code>8443</code>."
+            }]
+        },
+        {
+            "function": "verifyssl",
+            "type": "text",
+            "default_value":"false",
+            "options": [],
+            "localized": ["name", "description"],
+            "name" : [{
+                "language_code":"en_us",
+                "string" : "verify SSL"
+            },
+            {
+                "language_code": "es_es",
+                "string": "verificar SSL"
+            }],
+            "description": [{
+                "language_code":"en_us",
+                "string" : "verify SSL certificate validity <code>true|false</code>."
+            },
+            {
+                "language_code":"es_es",
+                "string" : "verificar la validez del certificado SSL <code>true|false</code>."
             }]
         },
         {

--- a/front/plugins/unifi_import/script.py
+++ b/front/plugins/unifi_import/script.py
@@ -2,7 +2,7 @@
 # Inspired by https://github.com/stevehoek/Pi.Alert
 
 # Example call
-# python3 /home/pi/pialert/front/plugins/unifi_import/script.py username=pialert password=passw0rd host=192.168.1.1 site=sdefault port=8443 verifyssl=false version=v5
+# python3 /home/pi/pialert/front/plugins/unifi_import/script.py username=pialert password=passw0rd host=192.168.1.1 sites=sdefault port=8443 verifyssl=false version=v5
 
 from __future__ import unicode_literals
 from time import sleep, time, strftime

--- a/front/plugins/unifi_import/script.py
+++ b/front/plugins/unifi_import/script.py
@@ -2,7 +2,7 @@
 # Inspired by https://github.com/stevehoek/Pi.Alert
 
 # Example call
-# python3 /home/pi/pialert/front/plugins/unifi_import/script.py username=pialert password=passw0rd  host=192.168.1.1 site=default  protocol=https:// port=8443
+# python3 /home/pi/pialert/front/plugins/unifi_import/script.py username=pialert password=passw0rd host=192.168.1.1 site=sdefault port=8443 verifyssl=false version=v5
 
 from __future__ import unicode_literals
 from time import sleep, time, strftime
@@ -31,8 +31,7 @@ last_run = curPath + '/last_result.log'
 def main():    
 
     # init global variables
-    global UNIFI_USERNAME, UNIFI_PASSWORD, UNIFI_HOST
-    global UNIFI_SITES, PORT, PROTOCOL, VERSION
+    global UNIFI_USERNAME, UNIFI_PASSWORD, UNIFI_HOST, UNIFI_SITES, PORT, VERIFYSSL, VERSION
 
     last_run_logfile = open(last_run, 'a') 
 
@@ -45,8 +44,8 @@ def main():
     parser.add_argument('password',  action="store",  help="Password used to login into the UNIFI controller")  
     parser.add_argument('host',  action="store",  help="Host url or IP address where the UNIFI controller is hosted (excluding http://)")  
     parser.add_argument('sites',  action="store",  help="Name of the sites (usually 'default', check the URL in your UniFi controller UI). Separated by comma (,) if passing multiple sites")      
-    parser.add_argument('protocol',  action="store",  help="https:// or http://")  
     parser.add_argument('port',  action="store",  help="Usually 8443")  
+    parser.add_argument('verifyssl',  action="store",  help="verify SSL certificate [true|false]")  
     parser.add_argument('version',  action="store",  help="The base version of the controller API [v4|v5|unifiOS|UDMP-unifiOS]")  
 
     values = parser.parse_args()
@@ -60,8 +59,8 @@ def main():
         UNIFI_PASSWORD = values.password.split('=')[1]
         UNIFI_HOST = values.host.split('=')[1]  
         UNIFI_SITES = values.sites.split('=')[1]  
-        PROTOCOL = values.protocol.split('=')[1]
         PORT = values.port.split('=')[1]
+        VERIFYSSL = values.verifyssl.split('=')[1]
         VERSION = values.version.split('=')[1]
         
         newEntries = get_entries(newEntries)  
@@ -75,6 +74,7 @@ def main():
 
 # -----------------------------------------------------------------------------
 def get_entries(newEntries):
+    global VERIFYSSL
 
     sites = []
 
@@ -84,10 +84,14 @@ def get_entries(newEntries):
     else:
         sites.append(UNIFI_SITES)
 
+    if (VERIFYSSL.upper() == "TRUE"):
+        VERIFYSSL = True
+    else:
+        VERIFYSSL = False
 
     for site in sites:
 
-        c = Controller(UNIFI_HOST, UNIFI_USERNAME, UNIFI_PASSWORD, version=VERSION, ssl_verify=False, site_id=site )
+        c = Controller(UNIFI_HOST, UNIFI_USERNAME, UNIFI_PASSWORD, port=PORT, version=VERSION, ssl_verify=VERIFYSSL, site_id=site )
 
         for ap in c.get_aps():
 


### PR DESCRIPTION
1) fix: port of UniFi controller not passed to [pyunify](https://github.com/finish06/pyunifi). now works for non-default ports of the UniFi controller.
2) new feature: allow user to define if pyunifi should verify the SSL certificate of the UniFi controller (defaults to `false`)
3) maintenace: remove option for protocol (http:// vs https://) as it is not passed to pyunify and pyunifi always uses https