### PR TITLE
Fixes in the Spanish translations of the Nmap Scan plugin

### DIFF
--- a/front/plugins/nmap_scan/config.json
+++ b/front/plugins/nmap_scan/config.json
@@ -210,7 +210,7 @@
                 },
 	    	    {
                 "language_code":"es_es",
-                "string" : "N/A"
+                "string" : "Enlaces HTTP/s"
                 }]
         } ,
         {
@@ -261,7 +261,7 @@
                 },
 	    	    {
                 "language_code":"es_es",
-                "string" : "N/A"
+                "string" : "Datos de usuario"
                 }]
         },       
         {
@@ -357,7 +357,11 @@
         "description": [{
             "language_code":"en_us",
             "string" : "This calls the script responsible for executing the NMAP scan."
-        }
+        },
+	{
+            "language_code":"es_es",
+            "string" : "Esto llama al script responsable de ejecutar el escaneo NMAP."
+        }		
         ]
     },
     {
@@ -428,7 +432,11 @@
             {
             "language_code": "en_us",
             "string": "Max run time per device in seconds."
-            }
+            },
+            {
+            "language_code": "es_es",
+            "string": "Tiempo máximo de ejecución por dispositivo en segundos."
+            }		
         ]
         },
         {


### PR DESCRIPTION
<h1>Pull Request</h1>
<h2>Description</h2>

Texts are missing in the Spanish translations, the Spanish translations of the nmap_scan plugin have been fixed.

<h2>Changes</h2>

<h3>Update config.json (front/plugins/nmap_scan/)</h3>

- Updated config.json file with new fixes in Spanish translations