### PR TITLE
Url fixes for the ImportCSV and ExportCSV functions in maintenance.php

### DIFF
--- a/front/maintenance.php
+++ b/front/maintenance.php
@@ -707,7 +707,7 @@ function askImportCSV() {
 function ImportCSV()
 {   
   // Execute
-  $.get('/php/server/devices.php?action=ImportCSV', function(msg) {
+  $.get('php/server/devices.php?action=ImportCSV', function(msg) {
     showMessage (msg);
   });
 }

--- a/front/maintenance.php
+++ b/front/maintenance.php
@@ -695,7 +695,7 @@ function askExportCSV() {
 function ExportCSV()
 { 
   // Execute
-  openInNewTab(window.location.origin + "/php/server/devices.php?action=ExportCSV")
+  openInNewTab("php/server/devices.php?action=ExportCSV")
 }
 
 // Import CSV


### PR DESCRIPTION
<h1>Pull Request</h1>
<h2>Description</h2>

The URLs of the ImportCSV and ExportCSV functions are not absolute paths and this causes an error with a reverse proxy configuration.

<h2>Changes</h2>

<h3>Update maintenance.php (front)</h3>

- Fixed URL of ImportCSV function
- Fixed URL of ExportCSV function
