### PR TITLE
Fix "saveSettings" function in settings.php for reverse proxies

### DIFF
--- a/front/settings.php
+++ b/front/settings.php
@@ -577,7 +577,7 @@ while ($row = $result -> fetchArray (SQLITE3_ASSOC)) {
     {
       $.ajax({
       method: "POST",
-      url: "../php/server/util.php",
+      url: "php/server/util.php",
       data: { 
         function: 'savesettings', 
         settings: JSON.stringify(collectSettings()) },


### PR DESCRIPTION
<h1>Pull Request</h1>
<h2>Description</h2>

Problem detected in the "saveSettings" function in "settings.php" with reverse proxies, it is corrected by changing relative url to absolute url so that it works correctly with reverse proxies.

<h2>Changes</h2>

<h3>Update settings.php (/front/)</h3>

- The "saveSettings" function is corrected by changing the relative url to an absolute url so that it works correctly with reverse proxies.