### PR TITLE
Pi.Alert - Fix "CMD" function in pihole_scan plugin

### DIFF
--- a/front/plugins/pihole_scan/config.json
+++ b/front/plugins/pihole_scan/config.json
@@ -81,7 +81,7 @@
     {
         "function": "CMD",
         "type": "text",
-        "default_value":"SELECT n.hwaddr AS Object_PrimaryID, 'null' AS Object_SecondaryID, datetime() AS DateTime, na.ip  AS Watched_Value1, n.lastQuery AS Watched_Value2, na.name AS Watched_Value3, n.macVendor AS Watched_Value4, {s-quote}null{s-quote} AS Extra, n.hwaddr AS ForeignKey FROM EXTERNAL_PIHOLE.Network AS n LEFT JOIN EXTERNAL_PIHOLE.Network_Addresses AS na ON na.network_id = n.id WHERE n.hwaddr NOT LIKE {s-quote}ip-%{s-quote} AND n.hwaddr <> {s-quote}00:00:00:00:00:00{s-quote};",
+        "default_value":"SELECT n.hwaddr AS Object_PrimaryID, {s-quote}null{s-quote} AS Object_SecondaryID, datetime() AS DateTime, na.ip  AS Watched_Value1, n.lastQuery AS Watched_Value2, na.name AS Watched_Value3, n.macVendor AS Watched_Value4, {s-quote}null{s-quote} AS Extra, n.hwaddr AS ForeignKey FROM EXTERNAL_PIHOLE.Network AS n LEFT JOIN EXTERNAL_PIHOLE.Network_Addresses AS na ON na.network_id = n.id WHERE n.hwaddr NOT LIKE {s-quote}ip-%{s-quote} AND n.hwaddr <> {s-quote}00:00:00:00:00:00{s-quote};",
         "options": [],
         "localized": ["name", "description"],
         "name" : [{


### PR DESCRIPTION
<h1>Pull Request</h1>
<h2>Description</h2>

Problem detected in the "default_value" string of the "CMD" function in "config.json" of the "pihole_scan" plugin, which causes it to cause an error in the Pi.Alert configuration file, it is corrected by adding {s-quote}.

<h2>Changes</h2>

<h3>Update config.json (/front/plugins/pihole_scan)</h3>

- "CMD" function is corrected by adding {s-quote} in "default_value"