### PR TITLE
Added functionality to perform a full import

### DIFF
--- a/front/plugins/unifi_import/config.json
+++ b/front/plugins/unifi_import/config.json
@@ -463,7 +463,12 @@
             "name": "version",
             "type": "setting",
             "value": "UNFIMP_version"
-        }
+        },
+	{	
+            "name": "fullimport",
+            "type": "setting",
+            "value": "UNFIMP_fullimport"
+	}
     ],
     "settings": [
         {

--- a/front/plugins/unifi_import/config.json
+++ b/front/plugins/unifi_import/config.json
@@ -435,7 +435,7 @@
         {
             "function": "CMD",
             "type": "text",
-            "default_value":"python3 /home/pi/pialert/front/plugins/unifi_import/script.py username={username} password={password}  host={host} sites={sites} port={port} verifyssl={verifyssl} version={version}",
+            "default_value":"python3 /home/pi/pialert/front/plugins/unifi_import/script.py username={username} password={password}  host={host} sites={sites} port={port} verifyssl={verifyssl} version={version} fullimport={fullimport}",
             "options": [],
             "localized": ["name", "description"],
             "name" : [{
@@ -548,7 +548,7 @@
             }],
             "description": [{
                 "language_code":"en_us",
-                "string" : "The port number where the UNIFI controller is runnig. Usually it is <code>8443</code>."
+                "string" : "The port number where the UNIFI controller is runnig. Usually it is <code>8443</code>, for UDM(P) devices its 443."
             },
             {
                 "language_code":"es_es",
@@ -722,7 +722,38 @@
             {
                 "language_code":"es_es",
                 "string" : "Envíe una notificación solo en estos estados. <code>new</code> significa que se descubrió un nuevo objeto único (una combinación única de PrimaryId y SecondaryId). <code>watched-changed</code> significa que las columnas <code>Watched_ValueN</code> seleccionadas cambiaron."
-            }] 
+            },
+            {
+            "function": "fullimport",
+            "type": "text.select",
+            "default_value":"disabled",
+            "options": ["disabled", "once", "always"],
+            "localized": ["name", "description"],
+            "name" :[{
+                "language_code":"en_us",
+                "string" : "Perform full import"
+            },
+            {
+                "language_code":"es_es",
+                "string" : "[ES] Perform full import"
+            },
+            {
+                "language_code":"de_de",
+                "string" : "Vollständigen Import durchführen"
+            }],
+            "description": [{
+                "language_code":"en_us",
+                "string" : "Enable a full import of all known devices by the controller instead of only the online ones. During the scan, all found devices appear online. If you select <code>once</code> the full import is only performed once and the status is set to <code>done</code> afterwards."
+            },
+            {
+                "language_code":"es_es",
+                "string" : "Translation Needed - Enable a full import of all known devices by the controller instead of only the online ones. During the scan, all found devices appear online. If you select <code>once</code> the full import is only performed once and the status is set to <code>done</code> afterwards."
+            },
+                {
+                "language_code":"de_de",
+                "string" : "Führe einen kompletten Import aller dem Controller bekannten Geräten durch. Während des Scans werden alle gefundenen Geräte einmalig als Online angezeigt. Bei der Auswahl von <code>once</code> wird der Scan einmalig durchgeführt und der Status anschliessend auf <code>done</code> gesetzt"
+                }]
+        }]
         }
     ]
 }

--- a/front/plugins/unifi_import/config.json
+++ b/front/plugins/unifi_import/config.json
@@ -1,372 +1,370 @@
 {
     "code_name": "unifi_import",
-    "unique_prefix": "UNFIMP",
-    "enabled": true,    
-    "data_source":  "script",
-    "show_ui": true,
     "data_filters": [
         {
-            "compare_column" : "Object_PrimaryID",
-            "compare_operator" : "==",
+            "compare_column": "Object_PrimaryID",
             "compare_field_id": "txtMacFilter",
-            "compare_js_template": "'{value}'.toString()", 
-            "compare_use_quotes": true 
+            "compare_js_template": "'{value}'.toString()",
+            "compare_operator": "==",
+            "compare_use_quotes": true
         }
     ],
-    "localized": ["display_name", "description", "icon"],
-    "mapped_to_table": "CurrentScan",    
-    "display_name" : [{
-        "language_code":"en_us",
-        "string" : "UniFi import"
-    },
-    {
-        "language_code":"es_es",
-        "string" : "Importación UniFi"
-    }],
-    "icon":[{
-        "language_code":"en_us",
-        "string" : "<i class=\"fa-solid fa-upload\"></i>"
-    },
-    {
-        "language_code":"es_es",
-        "string" : "<i class=\"fa-solid fa-upload\"></i>"
-    }],     
-    "description": [{
-        "language_code":"en_us",
-        "string" : "This plugin is used to import devices from an UNIFI controller."
-    },
-    {
-        "language_code":"es_es",
-        "string" : "Este plugin se utiliza para importar dispositivos desde un controlador UNIFI."
-    },
-    {
-        "language_code":"de_de",
-        "string" : "Dieses Plugin imporiert die Geräte von einem UNIFI Controller."
-    }],
-    "params" : [
+    "data_source": "script",
+    "database_column_definitions": [
         {
-            "name"  : "username",
-            "type"  : "setting",
-            "value" : "UNFIMP_username"
-        },
-        {
-            "name"  : "password",
-            "type"  : "setting",
-            "value" : "UNFIMP_password"
-        },
-        {
-            "name"  : "host",
-            "type"  : "setting",
-            "value" : "UNFIMP_host"
-        },
-        {
-            "name"  : "sites",
-            "type"  : "setting",
-            "value" : "UNFIMP_sites"
-        },
-        {
-            "name"  : "port",
-            "type"  : "setting",
-            "value" : "UNFIMP_port"
-        },
-        {
-            "name"  : "verifyssl",
-            "type"  : "setting",
-            "value" : "UNFIMP_verifyssl"
-        },
-        {
-            "name"  : "version",
-            "type"  : "setting",
-            "value" : "UNFIMP_version"
-        }
-    ], 
-    "database_column_definitions":
-    [          
-        {
-            "column": "Index",            
+            "column": "Index",
             "css_classes": "col-sm-2",
-            "show": false,
-            "type": "label",            
-            "default_value":"",
-            "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "N/A"
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "N/A"
                 },
                 {
-                "language_code":"es_es",
-                "string" : "N/A"
+                    "language_code": "es_es",
+                    "string": "N/A"
                 },
                 {
-                "language_code":"de_de",
-                "string" : "N/A"
+                    "language_code": "de_de",
+                    "string": "N/A"
                 }
-            ]
-        } ,
+            ],
+            "options": [],
+            "show": false,
+            "type": "label"
+        },
         {
             "column": "Plugin",
             "css_classes": "col-sm-2",
-            "show": false,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "N/A"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "N/A"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "N/A"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "N/A"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "N/A"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "N/A"
-                }]
+            "show": false,
+            "type": "label"
         },
         {
             "column": "Object_PrimaryID",
-            "mapped_to_column": "cur_MAC", 
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "device_mac",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "mapped_to_column": "cur_MAC",
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "MAC address"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Dirección MAC"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "MAC Adresse"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "MAC address"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Dirección MAC"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "MAC Adresse"
-                }]
+            "show": true,
+            "type": "device_mac"
         },
         {
             "column": "Object_SecondaryID",
-            "mapped_to_column": "cur_IP", 
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "device_ip",            
-            "default_value":"",
-            "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "IP"
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "mapped_to_column": "cur_IP",
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "IP"
                 },
                 {
-                "language_code":"es_es",
-                "string" : "IP"
+                    "language_code": "es_es",
+                    "string": "IP"
                 },
                 {
-                "language_code":"de_de",
-                "string" : "IP"
+                    "language_code": "de_de",
+                    "string": "IP"
                 }
-            ]
-        } ,
+            ],
+            "options": [],
+            "show": true,
+            "type": "device_ip"
+        },
         {
             "column": "DateTimeCreated",
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Created"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Creado"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Erstellt"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Created"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Creado"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Erstellt"
-                }]
+            "show": true,
+            "type": "label"
         },
         {
             "column": "DateTimeChanged",
-            "mapped_to_column": "cur_DateTime", 
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "mapped_to_column": "cur_DateTime",
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Changed"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Cambiado"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Angepasst"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Changed"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Cambiado"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Angepasst"
-                }]
+            "show": true,
+            "type": "label"
         },
         {
             "column": "Watched_Value1",
-            "mapped_to_column": "cur_Name", 
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "mapped_to_column": "cur_Name",
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Hostname"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Nombre de host"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Name des Hosts"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Hostname"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Nombre de host"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Name des Hosts"
-                }]
+            "show": true,
+            "type": "label"
         },
         {
-            "column": "Watched_Value2",            
+            "column": "Watched_Value2",
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Vendor"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Proveedor"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Hersteller"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Vendor"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Proveedor"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Hersteller"
-                }]
+            "show": true,
+            "type": "label"
         },
         {
             "column": "Watched_Value3",
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Type"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Tipo"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Typ"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Type"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Tipo"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Typ"
-                }]
-        } ,
+            "show": true,
+            "type": "label"
+        },
         {
             "column": "Watched_Value4",
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Online?"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "¿Online?"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Online?"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Online?"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "¿Online?"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Online?"
-                }]
-        } ,       
+            "show": true,
+            "type": "label"
+        },
         {
             "column": "UserData",
             "css_classes": "col-sm-2",
-            "show": false,
-            "type": "textbox_save",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Comments"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Comentarios"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Kommentar"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Comments"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Comentarios"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Kommentar"
-                }]
-        },        
+            "show": false,
+            "type": "textbox_save"
+        },
         {
             "column": "Dummy",
-            "mapped_to_column": "cur_ScanMethod", 
-            "mapped_to_column_data": {
-              "value": "UNFIMP"                
-            }, 
             "css_classes": "col-sm-2",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
-            "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Scan method"
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "mapped_to_column": "cur_ScanMethod",
+            "mapped_to_column_data": {
+                "value": "UNFIMP"
+            },
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Scan method"
                 },
                 {
-                "language_code":"es_es",
-                "string" : "Método de escaneo"
-                }]
-        } ,
+                    "language_code": "es_es",
+                    "string": "Método de escaneo"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Scan Methode"
+                }
+            ],
+            "options": [],
+            "show": true,
+            "type": "label"
+        },
         {
             "column": "Extra",
             "css_classes": "col-sm-3",
-            "show": true,
-            "type": "label",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Network"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Red"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Netzwerk"
+                }
+            ],
             "options": [],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Network"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Red"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Netzwerk"
-                }]
-        },        
+            "show": true,
+            "type": "label"
+        },
         {
             "column": "Status",
             "css_classes": "col-sm-1",
-            "show": true,
-            "type": "replace",            
-            "default_value":"",
+            "default_value": "",
+            "localized": [
+                "name"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Status"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Estado"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Status"
+                }
+            ],
             "options": [
                 {
                     "equals": "watched-not-changed",
@@ -385,376 +383,568 @@
                     "replacement": "<div style='text-align:center'><i class='fa-solid fa-question'></i></div>"
                 }
             ],
-            "localized": ["name"],
-            "name":[{
-                "language_code":"en_us",
-                "string" : "Status"
-                },
-                {
-                "language_code":"es_es",
-                "string" : "Estado"
-                },
-                {
-                "language_code":"de_de",
-                "string" : "Status"
-                }]
-        }            
+            "show": true,
+            "type": "replace"
+        }
     ],
-    "settings":[
+    "description": [
         {
-            "function": "RUN",            
-            "type": "text.select",            
-            "default_value":"disabled",
-            "options": ["disabled", "once", "schedule", "always_after_scan", "on_new_device"],
-            "localized": ["name", "description"],
-            "name" :[{
-                "language_code":"en_us",
-                "string" : "When to run"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Cuándo ejecutar"
-            },
-            {
-                "language_code":"de_de",
-                "string" : "Ausführungszeitpunkt"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "Enable import of devices from a UNIFI controller. If you select <code>schedule</code> the scheduling settings from below are applied. If you select <code>once</code> the scan is run only once on start of the application (container) or after you update your settings."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Habilite la importación de dispositivos desde un controlador UNIFI. Si selecciona <code>schedule</code>, se aplican las configuraciones de programación de abajo. Si selecciona <code>once</code>, el análisis se ejecuta solo una vez al iniciar la aplicación (contenedor) o después de actualizar su configuración."
-            },
+            "language_code": "en_us",
+            "string": "This plugin is used to import devices from an UNIFI controller."
+        },
+        {
+            "language_code": "es_es",
+            "string": "Este plugin se utiliza para importar dispositivos desde un controlador UNIFI."
+        },
+        {
+            "language_code": "de_de",
+            "string": "Dieses Plugin imporiert die Geräte von einem UNIFI Controller."
+        }
+    ],
+    "display_name": [
+        {
+            "language_code": "en_us",
+            "string": "UniFi import"
+        },
+        {
+            "language_code": "es_es",
+            "string": "Importación UniFi"
+        }
+    ],
+    "enabled": true,
+    "icon": [
+        {
+            "language_code": "en_us",
+            "string": "<i class=\"fa-solid fa-upload\"></i>"
+        },
+        {
+            "language_code": "es_es",
+            "string": "<i class=\"fa-solid fa-upload\"></i>"
+        }
+    ],
+    "localized": [
+        "display_name",
+        "description",
+        "icon"
+    ],
+    "mapped_to_table": "CurrentScan",
+    "params": [
+        {
+            "name": "username",
+            "type": "setting",
+            "value": "UNFIMP_username"
+        },
+        {
+            "name": "password",
+            "type": "setting",
+            "value": "UNFIMP_password"
+        },
+        {
+            "name": "host",
+            "type": "setting",
+            "value": "UNFIMP_host"
+        },
+        {
+            "name": "sites",
+            "type": "setting",
+            "value": "UNFIMP_sites"
+        },
+        {
+            "name": "port",
+            "type": "setting",
+            "value": "UNFIMP_port"
+        },
+        {
+            "name": "verifyssl",
+            "type": "setting",
+            "value": "UNFIMP_verifyssl"
+        },
+        {
+            "name": "version",
+            "type": "setting",
+            "value": "UNFIMP_version"
+        }
+    ],
+    "settings": [
+        {
+            "default_value": "disabled",
+            "description": [
                 {
-                "language_code":"de_de",
-                "string" : "Aktiviere den Import von einem UNIFI controller. Bei <code>schedule</code> werden die Richtzeiten von weiter unten verwendet. Bei der Auswahl <code>once</code> der Import wird einmalig beim Start der Applikation (container), oder nach einem Update der Einstellungen durchgeführt."
-                }]
+                    "language_code": "en_us",
+                    "string": "Enable import of devices from a UNIFI controller. If you select <code>schedule</code> the scheduling settings from below are applied. If you select <code>once</code> the scan is run only once on start of the application (container) or after you update your settings."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Habilite la importación de dispositivos desde un controlador UNIFI. Si selecciona <code>schedule</code>, se aplican las configuraciones de programación de abajo. Si selecciona <code>once</code>, el análisis se ejecuta solo una vez al iniciar la aplicación (contenedor) o después de actualizar su configuración."
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Aktiviere den Import von einem UNIFI controller. Bei <code>schedule</code> werden die Richtzeiten von weiter unten verwendet. Bei der Auswahl <code>once</code> der Import wird einmalig beim Start der Applikation (container), oder nach einem Update der Einstellungen durchgeführt."
+                }
+            ],
+            "function": "RUN",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "When to run"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Cuándo ejecutar"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Ausführungszeitpunkt"
+                }
+            ],
+            "options": [
+                "disabled",
+                "once",
+                "schedule",
+                "always_after_scan",
+                "on_new_device"
+            ],
+            "type": "text.select"
         },
         {
+            "default_value": "python3 /home/pi/pialert/front/plugins/unifi_import/script.py username={username} password={password}  host={host} sites={sites} port={port} verifyssl={verifyssl} version={version} fullimport={fullimport}",
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "Command to run. Not recommended to change."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Comando para ejecutar. No se recomienda cambiar."
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Befehl der ausgeführt wird. Anpassung nicht empfohlen"
+                }
+            ],
             "function": "CMD",
-            "type": "text",
-            "default_value":"python3 /home/pi/pialert/front/plugins/unifi_import/script.py username={username} password={password}  host={host} sites={sites} port={port} verifyssl={verifyssl} version={version} fullimport={fullimport}",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Command"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Comando"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Befehl"
+                }
+            ],
             "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Command"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Comando"
-            },
-            {
-                "language_code":"de_de",
-                "string" : "Befehl"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "Command to run. Not recommended to change."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Comando para ejecutar. No se recomienda cambiar."
-            },
-            {
-                "language_code":"de_de",
-                "string" : "Befehl der ausgeführt wird. Anpassung nicht empfohlen"
-            }]
+            "type": "text"
         },
         {
+            "default_value": "",
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "The username used to login into your UNIFI controller. It is recommended to create a read-only user account."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "El nombre de usuario utilizado para iniciar sesión en su controlador UNIFI. Se recomienda crear una cuenta de usuario de sólo lectura."
+                }
+            ],
             "function": "username",
-            "type": "text",
-            "default_value":"",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Username"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Nombre de usuario"
+                }
+            ],
             "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Username"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Nombre de usuario"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "The username used to login into your UNIFI controller. It is recommended to create a read-only user account."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "El nombre de usuario utilizado para iniciar sesión en su controlador UNIFI. Se recomienda crear una cuenta de usuario de sólo lectura."
-            }]
+            "type": "text"
         },
         {
+            "default_value": "",
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "The password used to login into your UNIFI controller."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "La contraseña utilizada para iniciar sesión en su controlador UNIFI."
+                }
+            ],
             "function": "password",
-            "type": "password",
-            "default_value":"",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Password"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Contraseña"
+                }
+            ],
             "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Password"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Contraseña"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "The password used to login into your UNIFI controller."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "La contraseña utilizada para iniciar sesión en su controlador UNIFI."
-            }]
+            "type": "password"
         },
         {
+            "default_value": "192.168.1.1",
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "The host (IP) where the UNIFI controller is runnig. Do NOT include the protocol (e.g. <code>https://</code>)"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "El host (IP) donde se ejecuta el controlador UNIFI. NO incluya el protocolo (por ejemplo, <code>https://</code>)"
+                }
+            ],
             "function": "host",
-            "type": "text",
-            "default_value":"192.168.1.1",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Host"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Host"
+                }
+            ],
             "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Host"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Host"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "The host (IP) where the UNIFI controller is runnig. Do NOT include the protocol (e.g. <code>https://</code>)"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "El host (IP) donde se ejecuta el controlador UNIFI. NO incluya el protocolo (por ejemplo, <code>https://</code>)"
-            }]
+            "type": "text"
         },
         {
+            "default_value": "8443",
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "The port number where the UNIFI controller is runnig. Usually it is <code>8443</code>, for UDM(P) devices its 443."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "El número de puerto donde se ejecuta el controlador UNIFI. Normalmente es <code>8443</code>."
+                }
+            ],
             "function": "port",
-            "type": "text",
-            "default_value":"8443",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Port number"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Número de puerto"
+                }
+            ],
             "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Port number"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Número de puerto"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "The port number where the UNIFI controller is runnig. Usually it is <code>8443</code>, for UDM(P) devices its 443."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "El número de puerto donde se ejecuta el controlador UNIFI. Normalmente es <code>8443</code>."
-            }]
+            "type": "text"
         },
         {
+            "default_value": "false",
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "verify SSL certificate validity <code>true|false</code>."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "verificar la validez del certificado SSL <code>true|false</code>."
+                }
+            ],
             "function": "verifyssl",
-            "type": "text",
-            "default_value":"false",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "verify SSL"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "verificar SSL"
+                }
+            ],
             "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "verify SSL"
-            },
-            {
-                "language_code": "es_es",
-                "string": "verificar SSL"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "verify SSL certificate validity <code>true|false</code>."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "verificar la validez del certificado SSL <code>true|false</code>."
-            }]
+            "type": "text"
         },
         {
             "function": "version",
             "type": "text",
-            "default_value":"v4",
+            "default_value": "v4",
             "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "API version"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Versión API"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "The base version of the Unify controller API. Supported values as of time of writing are <code>v4|v5|unifiOS|UDMP-unifiOS</code>."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "La versión base de la API del controlador Unify. Los valores admitidos al momento de escribir este artículo son <code>v4|v5|unifiOS|UDMP-unifiOS</code>."
-            }]
-        },
-        {
-            "function": "sites",
-            "type": "list",
-            "default_value":["default"],
-            "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "UNIFI sites"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Sitios UNIFI"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "The sites you want to connect to. Usually it is only one and the name is <code>default</code>. Check the URL in your UniFi controller UI if unsure."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Los sitios a los que desea conectarse. Generalmente es solo uno y el nombre es <code>default</code>. Verifique la URL en la interfaz de usuario de su controlador UniFi si no está seguro."
-            }]
-        },
-        {
-            "function": "RUN_SCHD",
-            "type": "text",
-            "default_value":"0 2 * * *",
-            "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Schedule"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Schedule"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "Only enabled if you select <code>schedule</code> in the <a href=\"#UNFIMP_RUN\"><code>UNFIMP_RUN</code> setting</a>. Make sure you enter the schedule in the correct cron-like format (e.g. validate at <a href=\"https://crontab.guru/\" target=\"_blank\">crontab.guru</a>). For example entering <code>0 4 * * *</code> will run the scan after 4 am in the <a onclick=\"toggleAllSettings()\" href=\"#TIMEZONE\"><code>TIMEZONE</code> you set above</a>. Will be run NEXT time the time passes."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Solo está habilitado si selecciona <code>schedule</code> en la configuración <a href=\"#UNFIMP_RUN\"><code>UNFIMP_RUN</code></a>. Asegúrese de ingresar la programación en el formato similar a cron correcto (por ejemplo, valide en <a href=\"https://crontab.guru/\" target=\"_blank\">crontab.guru</a>). Por ejemplo, ingresar <code>0 4 * * *</code> ejecutará el escaneo después de las 4 a.m. en el <a onclick=\"toggleAllSettings()\" href=\"#TIMEZONE\"><code>TIMEZONE</ código> que configuró arriba</a>. Se ejecutará la PRÓXIMA vez que pase el tiempo."
-            }]
-        },
-        {
-            "function": "RUN_TIMEOUT",
-            "type": "integer",
-            "default_value":5,
-            "options": [],
-            "localized": ["name", "description"],
-            "name" : [{
-                "language_code":"en_us",
-                "string" : "Run timeout"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Tiempo límite de ejecución"
-            },
-            {
-                "language_code":"de_de",
-                "string" : "Wartezeit"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "Maximum time in seconds to wait for the script to finish. If this time is exceeded the script is aborted."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Tiempo máximo en segundos para esperar a que finalice el script. Si se supera este tiempo, el script se cancela."
-            },
-            {
-                "language_code":"de_de",
-                "string" : "Maximale Laufzeit des Scripts. Nach Ablauf der Zeit wird das Script abgebrochen."
-            }]
-        },
-        {
-            "function": "WATCH",
-            "type": "text.multiselect",
-            "default_value":["Watched_Value1", "Watched_Value4"],
-            "options": ["Watched_Value1","Watched_Value2","Watched_Value3","Watched_Value4"],
-            "localized": ["name", "description"],
-            "name" :[{
-                "language_code":"en_us",
-                "string" : "Watched"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Visto"
-            }] ,
-            "description":[{
-                "language_code":"en_us",
-                "string" : "Send a notification if selected values change. Use <code>CTRL + Click</code> to select/deselect. <ul> <li><code>Watched_Value1</code> is Hostname </li><li><code>Watched_Value2</code> is Vendor </li><li><code>Watched_Value3</code> is Type </li><li><code>Watched_Value4</code> is Online </li></ul>"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Envíe una notificación si los valores seleccionados cambian. Utilice <code>CTRL + clic</code> para seleccionar/deseleccionar. <ul> <li><code>Watched_Value1</code> es el nombre de host </li><li><code>Watched_Value2</code> es el proveedor </li><li><code>Watched_Value3</code> es el tipo </li><li><code>Watched_Value4</code> es Online </li></ul>"
-            }] 
-        },
-        {
-            "function": "REPORT_ON",
-            "type": "text.multiselect",
-            "default_value":["new","watched-changed"],
-            "options": ["new","watched-changed","watched-not-changed", "missing-in-last-scan"],
-            "localized": ["name", "description"],
-            "name" :[{
-                "language_code":"en_us",
-                "string" : "Report on"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Informar sobre"
-            }] ,
-            "description":[{
-                "language_code":"en_us",
-                "string" : "Send a notification only on these statuses. <code>new</code> means a new unique (unique combination of PrimaryId and SecondaryId) object was discovered. <code>watched-changed</code> means that selected <code>Watched_ValueN</code> columns changed."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Envíe una notificación solo en estos estados. <code>new</code> significa que se descubrió un nuevo objeto único (una combinación única de PrimaryId y SecondaryId). <code>watched-changed</code> significa que las columnas <code>Watched_ValueN</code> seleccionadas cambiaron."
-            },
-            {
-            "function": "fullimport",
-            "type": "text.select",
-            "default_value":"disabled",
-            "options": ["disabled", "once", "always"],
-            "localized": ["name", "description"],
-            "name" :[{
-                "language_code":"en_us",
-                "string" : "Perform full import"
-            },
-            {
-                "language_code":"es_es",
-                "string" : "[ES] Perform full import"
-            },
-            {
-                "language_code":"de_de",
-                "string" : "Vollständigen Import durchführen"
-            }],
-            "description": [{
-                "language_code":"en_us",
-                "string" : "Enable a full import of all known devices by the controller instead of only the online ones. During the scan, all found devices appear online. If you select <code>once</code> the full import is only performed once and the status is set to <code>done</code> afterwards."
-            },
-            {
-                "language_code":"es_es",
-                "string" : "Translation Needed - Enable a full import of all known devices by the controller instead of only the online ones. During the scan, all found devices appear online. If you select <code>once</code> the full import is only performed once and the status is set to <code>done</code> afterwards."
-            },
+            "localized": ["name","description"],
+            "name": [
                 {
-                "language_code":"de_de",
-                "string" : "Führe einen kompletten Import aller dem Controller bekannten Geräten durch. Während des Scans werden alle gefundenen Geräte einmalig als Online angezeigt. Bei der Auswahl von <code>once</code> wird der Scan einmalig durchgeführt und der Status anschliessend auf <code>done</code> gesetzt"
-                }]
-        }]
+                    "language_code": "en_us",
+                    "string": "API version"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Versión API"
+                }
+            ],
+	    "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "The base version of the Unify controller API. Supported values as of time of writing are <code>v4|v5|unifiOS|UDMP-unifiOS</code>."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "La versión base de la API del controlador Unify. Los valores admitidos al momento de escribir este artículo son <code>v4|v5|unifiOS|UDMP-unifiOS</code>."
+                }
+            ]
+            
+        },
+        {
+            "default_value": [
+                "default"
+            ],
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "The sites you want to connect to. Usually it is only one and the name is <code>default</code>. Check the URL in your UniFi controller UI if unsure."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Los sitios a los que desea conectarse. Generalmente es solo uno y el nombre es <code>default</code>. Verifique la URL en la interfaz de usuario de su controlador UniFi si no está seguro."
+                }
+            ],
+            "function": "sites",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "UNIFI sites"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Sitios UNIFI"
+                }
+            ],
+            "options": [],
+            "type": "list"
+        },
+        {
+            "default_value": "0 2 * * *",
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "Only enabled if you select <code>schedule</code> in the <a href=\"#UNFIMP_RUN\"><code>UNFIMP_RUN</code> setting</a>. Make sure you enter the schedule in the correct cron-like format (e.g. validate at <a href=\"https://crontab.guru/\" target=\"_blank\">crontab.guru</a>). For example entering <code>0 4 * * *</code> will run the scan after 4 am in the <a onclick=\"toggleAllSettings()\" href=\"#TIMEZONE\"><code>TIMEZONE</code> you set above</a>. Will be run NEXT time the time passes."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Solo está habilitado si selecciona <code>schedule</code> en la configuración <a href=\"#UNFIMP_RUN\"><code>UNFIMP_RUN</code></a>. Asegúrese de ingresar la programación en el formato similar a cron correcto (por ejemplo, valide en <a href=\"https://crontab.guru/\" target=\"_blank\">crontab.guru</a>). Por ejemplo, ingresar <code>0 4 * * *</code> ejecutará el escaneo después de las 4 a.m. en el <a onclick=\"toggleAllSettings()\" href=\"#TIMEZONE\"><code>TIMEZONE</ código> que configuró arriba</a>. Se ejecutará la PRÓXIMA vez que pase el tiempo."
+                }
+            ],
+            "function": "RUN_SCHD",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Schedule"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Schedule"
+                }
+            ],
+            "options": [],
+            "type": "text"
+        },
+        {
+            "default_value": 5,
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "Maximum time in seconds to wait for the script to finish. If this time is exceeded the script is aborted."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Tiempo máximo en segundos para esperar a que finalice el script. Si se supera este tiempo, el script se cancela."
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Maximale Laufzeit des Scripts. Nach Ablauf der Zeit wird das Script abgebrochen."
+                }
+            ],
+            "function": "RUN_TIMEOUT",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Run timeout"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Tiempo límite de ejecución"
+                },
+                {
+                    "language_code": "de_de",
+                    "string": "Wartezeit"
+                }
+            ],
+            "options": [],
+            "type": "integer"
+        },
+        {
+            "default_value": [
+                "Watched_Value1",
+                "Watched_Value4"
+            ],
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "Send a notification if selected values change. Use <code>CTRL + Click</code> to select/deselect. <ul> <li><code>Watched_Value1</code> is Hostname </li><li><code>Watched_Value2</code> is Vendor </li><li><code>Watched_Value3</code> is Type </li><li><code>Watched_Value4</code> is Online </li></ul>"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Envíe una notificación si los valores seleccionados cambian. Utilice <code>CTRL + clic</code> para seleccionar/deseleccionar. <ul> <li><code>Watched_Value1</code> es el nombre de host </li><li><code>Watched_Value2</code> es el proveedor </li><li><code>Watched_Value3</code> es el tipo </li><li><code>Watched_Value4</code> es Online </li></ul>"
+                }
+            ],
+            "function": "WATCH",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Watched"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Visto"
+                }
+            ],
+            "options": [
+                "Watched_Value1",
+                "Watched_Value2",
+                "Watched_Value3",
+                "Watched_Value4"
+            ],
+            "type": "text.multiselect"
+        },
+        {
+            "default_value": [
+                "new",
+                "watched-changed"
+            ],
+            "description": [
+                {
+                    "language_code": "en_us",
+                    "string": "Send a notification only on these statuses. <code>new</code> means a new unique (unique combination of PrimaryId and SecondaryId) object was discovered. <code>watched-changed</code> means that selected <code>Watched_ValueN</code> columns changed."
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Envíe una notificación solo en estos estados. <code>new</code> significa que se descubrió un nuevo objeto único (una combinación única de PrimaryId y SecondaryId). <code>watched-changed</code> significa que las columnas <code>Watched_ValueN</code> seleccionadas cambiaron."
+                }
+            ],
+            "function": "REPORT_ON",
+            "localized": [
+                "name",
+                "description"
+            ],
+            "name": [
+                {
+                    "language_code": "en_us",
+                    "string": "Report on"
+                },
+                {
+                    "language_code": "es_es",
+                    "string": "Informar sobre"
+                }
+            ],
+            "options": [
+                "new",
+                "watched-changed",
+                "watched-not-changed",
+                "missing-in-last-scan"
+            ],
+            "type": "text.multiselect"
+        },
+        {
+        "default_value": "disabled",
+        "description": [
+            {
+                "language_code": "en_us",
+                "string": "Enable a full import of all known devices by the controller instead of only the online ones. During the scan, all found devices appear online. If you select <code>once</code> the full import is only performed once and the status is set to <code>done</code> afterwards."
+            },
+            {
+                "language_code": "es_es",
+                "string": "Translation Needed - Enable a full import of all known devices by the controller instead of only the online ones. During the scan, all found devices appear online. If you select <code>once</code> the full import is only performed once and the status is set to <code>done</code> afterwards."
+            },
+            {
+                "language_code": "de_de",
+                "string": "Führe einen kompletten Import aller dem Controller bekannten Geräten durch. Während des Scans werden alle gefundenen Geräte einmalig als Online angezeigt. Bei der Auswahl von <code>once</code> wird der Scan einmalig durchgeführt und der Status anschliessend auf <code>done</code> gesetzt"
+            }
+        ],
+        "function": "fullimport",
+        "localized": [
+            "name",
+            "description"
+        ],
+        "name": [
+            {
+                "language_code": "en_us",
+                "string": "Perform full import"
+            },
+            {
+                "language_code": "es_es",
+                "string": "[ES] Perform full import"
+            },
+            {
+                "language_code": "de_de",
+                "string": "Vollständigen Import durchführen"
+            }
+        ],
+        "options": [
+            "disabled",
+            "once",
+            "always"
+        ],
+        "type": "text.select"
         }
-    ]
+    ],
+    "show_ui": true,
+    "unique_prefix": "UNFIMP"
 }
-

--- a/front/plugins/unifi_import/script.py
+++ b/front/plugins/unifi_import/script.py
@@ -52,7 +52,7 @@ def main():
     parser.add_argument('port',  action="store",  help="Usually 8443")
     parser.add_argument('verifyssl',  action="store",  help="verify SSL certificate [true|false]")
     parser.add_argument('version',  action="store",  help="The base version of the controller API [v4|v5|unifiOS|UDMP-unifiOS]")
-    parser.add_argument('fullimport', action="store", help="Defines if a full import or only online devices hould be imported [disabled|once|always]"
+    parser.add_argument('fullimport', action="store", help="Defines if a full import or only online devices hould be imported [disabled|once|always]")
 
     values = parser.parse_args()
 
@@ -85,7 +85,7 @@ def main():
 
 # .............................................
 
-def get_entries(plugin_objects: plugin_helper.Plugin_Objects) -> plugin_helper.Plugin_Objects:
+def get_entries(plugin_objects: Plugin_Objects) -> Plugin_Objects:
     global VERIFYSSL
 
     # check if the full run must be run:
@@ -159,7 +159,7 @@ def get_entries(plugin_objects: plugin_helper.Plugin_Objects) -> plugin_helper.P
         # get_users() returns all clients known by the controller
         for user in c.get_users():
 
-            mylog('verbose', [f'{json.dumps(user)}'])
+            #mylog('verbose', [f'{json.dumps(user)}'])
 
             name = get_unifi_val(user, 'name')
             hostName = get_unifi_val(user, 'hostname')
@@ -186,6 +186,8 @@ def get_entries(plugin_objects: plugin_helper.Plugin_Objects) -> plugin_helper.P
                 )
 
     # check if the lockfile needs to be adapted
+
+    mylog('verbose', [f'[UNFIMP] check if Lock file needs to be modified'])
     set_lock_file_value(FULL_IMPORT, lock_file_value)
 
 
@@ -224,34 +226,39 @@ def set_name(name: str, hostName: str) -> str:
 # -----------------------------------------------------------------------------
 def set_lock_file_value(config_value: str, lock_file_value: bool) -> None:
 
+    mylog('verbose', [f'[UNFIMP] Lock Params: config_value={config_value}, lock_file_value={lock_file_value}'])
     # set lock if 'once' is set and the lock is not set
     if config_value == 'once' and lock_file_value is False:
         out = 1
     # reset lock if not 'once' is set and the lock is present
-    if config_value != 'once' and lock_file_value is True:
+    elif config_value != 'once' and lock_file_value is True:
         out = 0
     else:
-        mylog('debug', [f'[UNFIMP] No change on lock file needed']))
+        mylog('verbose', [f'[UNFIMP] No change on lock file needed'])
         return
 
-    mylog('verbose', [f'[UNFIMP] Setting lock value for "full import" to {out}']))
-    with open(LOCK_FILE 'w') as lock_file:
-            lock_file.write(str(value))
+    mylog('verbose', [f'[UNFIMP] Setting lock value for "full import" to {out}'])
+    with open(LOCK_FILE, 'w') as lock_file:
+            lock_file.write(str(out))
 
 
 # -----------------------------------------------------------------------------
 def read_lock_file() -> bool:
-    with open(LOCK_FILE, 'w') as lock_file:
-        return bool(int(lock_file.readline()))
+
+    try:
+        with open(LOCK_FILE, 'r') as lock_file:
+            return bool(int(lock_file.readline()))
+    except (FileNotFoundError, ValueError):
+        return False
 
 
 # -----------------------------------------------------------------------------
 def check_full_run_state(config_value: str, lock_file_value: bool) -> bool:
     if config_value == 'always' or (config_value == 'once' and lock_file_value == False):
-        mylog('debug', [f'[UNFIMP] Full import needs to be done: config_value: {config_value} and lock_file_value: {lock_file_value}']))
+        mylog('verbose', [f'[UNFIMP] Full import needs to be done: config_value: {config_value} and lock_file_value: {lock_file_value}'])
         return True
     else:
-        mylog('debug', [f'[UNFIMP] Full import NOT needed: config_value: {config_value} and lock_file_value: {lock_file_value}']))
+        mylog('verbose', [f'[UNFIMP] Full import NOT needed: config_value: {config_value} and lock_file_value: {lock_file_value}'])
         return False
 
 #===============================================================================

--- a/front/plugins/unifi_import/script.py
+++ b/front/plugins/unifi_import/script.py
@@ -2,7 +2,7 @@
 # Inspired by https://github.com/stevehoek/Pi.Alert
 
 # Example call
-# python3 /home/pi/pialert/front/plugins/unifi_import/script.py username=pialert password=passw0rd host=192.168.1.1 site=default protocol=https port=8443 version='UDMP-unifiOS'
+# python3 /home/pi/pialert/front/plugins/unifi_import/script.py username=pialert password=passw0rd host=192.168.1.1 site=default protocol=https port=443 verifyssl=false version='UDMP-unifiOS'
 # python3 /home/pi/pialert/front/plugins/unifi_import/script.py username=pialert password=passw0rd host=192.168.1.1 sites=sdefault port=8443 verifyssl=false version=v5
 
 from __future__ import unicode_literals
@@ -28,6 +28,7 @@ from logger import mylog
 CUR_PATH = str(pathlib.Path(__file__).parent.resolve())
 LOG_FILE = os.path.join(CUR_PATH, 'script.log')
 RESULT_FILE = os.path.join(CUR_PATH, 'last_result.log')
+LOCK_FILE = os.path.join(CUR_PATH, 'full_run.lock')
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -39,7 +40,7 @@ def main():
 
     
     # init global variables
-    global UNIFI_USERNAME, UNIFI_PASSWORD, UNIFI_HOST, UNIFI_SITES, PORT, VERIFYSSL, VERSION
+    global UNIFI_USERNAME, UNIFI_PASSWORD, UNIFI_HOST, UNIFI_SITES, PORT, VERIFYSSL, VERSION, FULL_IMPORT
 
 
     parser = argparse.ArgumentParser(description='Import devices from a UNIFI controller')
@@ -51,8 +52,12 @@ def main():
     parser.add_argument('port',  action="store",  help="Usually 8443")
     parser.add_argument('verifyssl',  action="store",  help="verify SSL certificate [true|false]")
     parser.add_argument('version',  action="store",  help="The base version of the controller API [v4|v5|unifiOS|UDMP-unifiOS]")
+    parser.add_argument('fullimport', action="store", help="Defines if a full import or only online devices hould be imported [disabled|once|always]"
 
     values = parser.parse_args()
+
+
+
 
     # parse output
     plugin_objects = Plugin_Objects(RESULT_FILE)
@@ -69,6 +74,7 @@ def main():
         PORT = values.port.split('=')[1]
         VERIFYSSL = values.verifyssl.split('=')[1]
         VERSION = values.version.split('=')[1]
+        FULL_IMPORT = values.fullimport.split('=')[1]
 
         plugin_objects = get_entries(plugin_objects)
 
@@ -79,8 +85,13 @@ def main():
 
 # .............................................
 
-def get_entries(plugin_objects):
+def get_entries(plugin_objects: plugin_helper.Plugin_Objects) -> plugin_helper.Plugin_Objects:
     global VERIFYSSL
+
+    # check if the full run must be run:
+    lock_file_value = read_lock_file()
+    perform_full_run = check_full_run_state(FULL_IMPORT, lock_file_value)
+
 
     sites = []
 
@@ -157,7 +168,7 @@ def get_entries(plugin_objects):
 
             status = 1 if user['mac'] in online_macs else 0
 
-            if status == 1:
+            if status == 1 or perform_full_run is True:
 
                 ipTmp = get_unifi_val(user, 'last_ip')
 
@@ -174,10 +185,14 @@ def get_entries(plugin_objects):
                     extra=get_unifi_val(user, 'last_connection_network_name')
                 )
 
-    
+    # check if the lockfile needs to be adapted
+    set_lock_file_value(FULL_IMPORT, lock_file_value)
+
+
     mylog('verbose', [f'[UNFIMP] Found {len(plugin_objects)} Clients overall'])
 
     return plugin_objects
+
 
 # -----------------------------------------------------------------------------
 def get_unifi_val(obj, key):
@@ -192,8 +207,8 @@ def get_unifi_val(obj, key):
 
     return 'null'
 
-# -----------------------------------------------------------------------------
 
+# -----------------------------------------------------------------------------
 def set_name(name: str, hostName: str) -> str:
 
     if name != 'null':
@@ -204,6 +219,40 @@ def set_name(name: str, hostName: str) -> str:
 
     else:
         return 'null'
+
+
+# -----------------------------------------------------------------------------
+def set_lock_file_value(config_value: str, lock_file_value: bool) -> None:
+
+    # set lock if 'once' is set and the lock is not set
+    if config_value == 'once' and lock_file_value is False:
+        out = 1
+    # reset lock if not 'once' is set and the lock is present
+    if config_value != 'once' and lock_file_value is True:
+        out = 0
+    else:
+        mylog('debug', [f'[UNFIMP] No change on lock file needed']))
+        return
+
+    mylog('verbose', [f'[UNFIMP] Setting lock value for "full import" to {out}']))
+    with open(LOCK_FILE 'w') as lock_file:
+            lock_file.write(str(value))
+
+
+# -----------------------------------------------------------------------------
+def read_lock_file() -> bool:
+    with open(LOCK_FILE, 'w') as lock_file:
+        return bool(int(lock_file.readline()))
+
+
+# -----------------------------------------------------------------------------
+def check_full_run_state(config_value: str, lock_file_value: bool) -> bool:
+    if config_value == 'always' or (config_value == 'once' and lock_file_value == False):
+        mylog('debug', [f'[UNFIMP] Full import needs to be done: config_value: {config_value} and lock_file_value: {lock_file_value}']))
+        return True
+    else:
+        mylog('debug', [f'[UNFIMP] Full import NOT needed: config_value: {config_value} and lock_file_value: {lock_file_value}']))
+        return False
 
 #===============================================================================
 # BEGIN


### PR DESCRIPTION
This feature gives the user the option to perform a full import of all devices known to the unifi controller

- user has the option to perform the import once or always
- on 'once' the import is done once - during this run all devices are shown online, afterwards only the actually online devices are shown online
- on 'always' the import is done during each unifi_import run - all devices are shown online continously

You might want to double check, as I had to merge some changes in the config.json file for the plugin, not sure if it worked out correctly


p.s.: sorry for the delay