### PR TITLE
Update update_vendors.sh

### DIFF
--- a/back/update_vendors.sh
+++ b/back/update_vendors.sh
@@ -26,10 +26,7 @@ sudo cp *.csv 2_backup
 echo ""
 echo Download Start
 echo ""
-sudo curl $1  -LO https://standards-oui.ieee.org/iab/iab.csv \
-              -LO https://standards-oui.ieee.org/iab/iab.txt \
-              -LO https://standards-oui.ieee.org/oui28/mam.csv \
-              -LO https://standards-oui.ieee.org/iab/iab.txt \
+sudo curl $1  -LO https://standards-oui.ieee.org/oui28/mam.csv \
               -LO https://standards-oui.ieee.org/oui28/mam.csv \
               -LO https://standards-oui.ieee.org/oui28/mam.txt \
               -LO https://standards-oui.ieee.org/oui36/oui36.csv \
@@ -48,7 +45,6 @@ sudo mkdir -p 2_backup
 sudo cp *.txt 2_backup
 
 # Update from /usb/lib/ieee-data
-sudo get-iab -v
 sudo get-oui -v
 
 # Update from ieee website


### PR DESCRIPTION
iab is no longer needed and was depreciated in arp-scan 1.10 
get-oui is now used to fetch all of the Ethernet MAC-Vendor mappings from the various IEEE registries.