### PR TITLE
Fix device types not loading in device details page

### DIFF
--- a/front/php/server/devices.php
+++ b/front/php/server/devices.php
@@ -857,8 +857,6 @@ function getDevices() {
 function getDeviceTypes() {
   global $db;
 
-  $networkTypes = getNetworkTypes();
-
   // SQL
   $sql = 'SELECT DISTINCT 9 as dev_Order, dev_DeviceType
           FROM Devices


### PR DESCRIPTION
Device Types in the Device details view are not loaded. The API request results in a 500 Internal Server Error.

The issue stems from a missed removal of `getNetworkTypes()` call inside the `getDeviceTypes()` function in `php/server/devices.php` in the commit https://github.com/jokob-sk/Pi.Alert/commit/07367a2ca32f253b6d9890b2e104df6e82bef05f.

Output of `getDeviceTypes()` function call:

```console
root@nas:/home/pi/pialert/front/php/server# php -r "require 'devices.php'; getDeviceTypes();"
PHP Fatal error:  Uncaught Error: Call to undefined function getNetworkTypes() in /home/pi/pialert/front/php/server/devices.php:860
Stack trace:
#0 Command line code(1): getDeviceTypes()
#1 {main}
  thrown in /home/pi/pialert/front/php/server/devices.php on line 860
```

This PR fixes that by removing the already unused call to `getNetworkTypes()`. Tested locally using the provided docker-compose file.