### PR TITLE
Add option to set IP Address for web interface in Docker env

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -35,6 +35,7 @@ docker run -d --rm --network=host \
 | Variable | Description | Default |
 | :------------- |:-------------| -----:|
 | `PORT`      |Port of the web interface  |  `20211` |
+| `LISTEN_ADDR`      |Set the specific IP Address for the web interface  |  `0.0.0.0` |
 |`TZ` |Time zone to display stats correctly. Find your time zone [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)  |  `Europe/Berlin` |
 |`HOST_USER_GID`    |User ID (UID) to map the user in the container to a server user with sufficient read&write permissions on the mapped files   |  `1000` |
 |`HOST_USER_ID` |User Group ID (GID)  to map the user group in the container to a server user group with sufficient read&write permissions on the mapped files    |    `1000` |

--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -48,6 +48,10 @@ sudo ln -s "$INSTALL_DIR/pialert/install/default" /etc/nginx/sites-available/def
 # use user-supplied port
 sudo sed -i 's/listen 80/listen '"$PORT"'/g' /etc/nginx/sites-available/default
 
+# Change web interface address if set
+if [ -n "${LISTEN_ADDR}" ]; then  
+  sed -ie 's/listen /listen '${LISTEN_ADDR}:'/g' /etc/nginx/sites-available/default
+fi
 
 # Run the hardware vendors update at least once
 echo "[INSTALL] Run the hardware vendors update"


### PR DESCRIPTION
This could be useful when using multiple subnets to hide the web interface from all untrusted networks by adding variables in the docker startup script to set the listener address for the nginx webserver.

Set "LISTEN_ADDR" in the docker environment variable. (this is an optional variable, and if not set, nginx listens to all container network interfaces.)
**Example in docker environment**:
LISTEN_ADDR=172.17.0.1