### PR TITLE
Fix DB Clean plugin new devices deletion bug

### DIFF
--- a/front/plugins/db_cleanup/script.py
+++ b/front/plugins/db_cleanup/script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # test script by running:
-# /home/pi/pialert/front/plugins/db_cleanup/script.py pluginskeephistory=250 hourstokeepnewdevice=48 daystokeepevents=90
+# /home/pi/pialert/front/plugins/db_cleanup/script.py pluginskeephistory=250 hourstokeepnewdevice=48 daystokeepevents=90 pholuskeepdays=30
 
 import os
 import pathlib
@@ -35,10 +35,10 @@ def main():
     
     values = parser.parse_args()
 
-    PLUGINS_KEEP_HIST     = values.pluginskeephistory.split('=')[1]
-    HRS_TO_KEEP_NEWDEV    = values.hourstokeepnewdevice.split('=')[1]
-    DAYS_TO_KEEP_EVENTS   = values.daystokeepevents.split('=')[1]
-    PHOLUS_DAYS_DATA      = values.pholuskeepdays.split('=')[1]
+    PLUGINS_KEEP_HIST     = int(values.pluginskeephistory.split('=')[1])
+    HRS_TO_KEEP_NEWDEV    = int(values.hourstokeepnewdevice.split('=')[1])
+    DAYS_TO_KEEP_EVENTS   = int(values.daystokeepevents.split('=')[1])
+    PHOLUS_DAYS_DATA      = int(values.pholuskeepdays.split('=')[1])
 
     mylog('verbose', ['[DBCLNP] In script'])     
 


### PR DESCRIPTION
Fixes a bug introduced in [this refactor commit](https://github.com/jokob-sk/Pi.Alert/commit/a5b952f18c21fea7983efa56399c12f254d6800e) which caused the DB cleaning script to delete all new devices even if the configuration parameter `hourstokeepnewdevice` has a value of `0`.

The cause is that before the refactor the parameters of the function cleanup_database were integer values, however after the refactor they are string values, causing this issue and potentially other unexpected behaviors.

This may be related to #474 and #481