### PR TITLE
Fix date parsing for release check

### DIFF
--- a/pialert/helper.py
+++ b/pialert/helper.py
@@ -709,9 +709,9 @@ def checkNewVersion():
 
         dateTimeStr = data[0]["published_at"]
 
-        realeaseTimestamp = int(datetime.datetime.strptime(dateTimeStr, '%Y-%m-%dT%H:%M:%SZ').strftime('%s'))
+        releaseTimestamp = int(datetime.datetime.strptime(dateTimeStr, '%Y-%m-%dT%H:%M:%S%z').timestamp())
 
-        if realeaseTimestamp > buildTimestamp + 600:
+        if releaseTimestamp > buildTimestamp + 600:
             mylog('none', ["[Version check] New version of the container available!"])
             newVersion = True       
         else:


### PR DESCRIPTION
Fixes an issue with date parsing for update check. 

If the host has a timezone explicitly set other than UTC with a TZ environment variable, the parsing of the downloaded release date does not produce the expected timestamp to properly compare against the buildtimestamp. This makes the parser timezone aware (the %z addition) and uses the builtin timestamp function to produce the expected timestamp. 

Tested on host with TZ set:
```
>>> import datetime
>>> dateTimeStr = '2023-11-11T01:48:45Z'
>>> int(datetime.datetime.strptime(dateTimeStr, '%Y-%m-%dT%H:%M:%SZ').strftime('%s'))
1699685325
>>> int(datetime.datetime.strptime(dateTimeStr, '%Y-%m-%dT%H:%M:%S%z').timestamp())
1699667325
>>> release = int(datetime.datetime.strptime(dateTimeStr, '%Y-%m-%dT%H:%M:%S%z').timestamp())
>>> release
1699667325
>>> buildtime = 1699667486
>>> release > buildtime + 600
False
>>> release > buildtime
False
>>> release > (buildtime + 600)
False
>>> newTime = '2023-11-20T01:48:45Z'
>>> newrelease = int(datetime.datetime.strptime(newTime, '%Y-%m-%dT%H:%M:%S%z').timestamp())
>>> release > (buildtime + 600)
False
>>> newrelease > (buildtime + 600)
True
>>>
```