### PR TITLE
FIX unable to send mail with publisher mail plugin

### DIFF
--- a/front/plugins/_publisher_email/email_smtp.py
+++ b/front/plugins/_publisher_email/email_smtp.py
@@ -109,12 +109,12 @@ def send(pHTML, pText):
 
     if get_setting_value("LOG_LEVEL") == 'debug':
 
-        send_email(msg)
+        send_email(msg,smtp_timeout)
 
     else:
 
         try:
-            send_email(msg)
+            send_email(msg,smtp_timeout)
             
         except smtplib.SMTPAuthenticationError as e:            
             mylog('none', ['      ERROR: Couldn\'t connect to the SMTP server (SMTPAuthenticationError)'])
@@ -132,7 +132,7 @@ def send(pHTML, pText):
             mylog('none', ['      ERROR: ', str(e)])      
 
 # ----------------------------------------------------------------------------------
-def send_email(msg):
+def send_email(msg,smtp_timeout):
     # Send mail
     if get_setting_value('SMTP_FORCE_SSL'):
         mylog('debug', ['SMTP_FORCE_SSL == True so using .SMTP_SSL()'])


### PR DESCRIPTION
# Description
Sending mail with the publisher mail plugin resulted in error
`NameError: name 'smtp_timeout' is not defined`

# Changes
Fix to /front/plugins/_publisher_email/email_smtp.py

- `smtp_timeout` is now an argument to the `send_mail` function
